### PR TITLE
Back 2076 add auth support into flex

### DIFF
--- a/lib/receivers/httpReceiver.js
+++ b/lib/receivers/httpReceiver.js
@@ -120,6 +120,10 @@ module.exports = (() => {
     };
   }
 
+  function getAuthBody(result) {
+    return result.response.body;
+  }
+
   function getDiscoveryBody(result) {
     return result.discoveryObjects;
   }
@@ -172,6 +176,9 @@ module.exports = (() => {
           case 'serviceDiscovery':
             body = getDiscoveryBody(result);
             break;
+          case 'auth':
+            body = getAuthBody(result);
+            break;
           default:
             body = {};
         }
@@ -191,10 +198,26 @@ module.exports = (() => {
     });
   }
 
-  function discover(req, res, next) {
+  function buildDiscoverTask(req, res, next) {
     req.task = {
       taskType: 'serviceDiscovery',
       request: {},
+      response: {}
+    };
+
+    next();
+  }
+
+  function buildAuthTask(req, res, next) {
+    req.task = {
+      taskType: 'auth',
+      request: {
+        body: {
+          username: req.body.username,
+          password: req.body.password,
+          options: req.body.options
+        }
+      },
       response: {}
     };
 
@@ -233,8 +256,9 @@ module.exports = (() => {
 
     // FlexFunctions route
     router.post('/_flexFunctions/:handlerName', mapPostToElements, generateBaseTask, addFunctionsTaskAttributes, appendQuery, appendId, appendBody, sendTask);
+    router.post('/_auth/authenticate', buildAuthTask, sendTask);
 
-    router.post('/_command/discover', discover, sendTask);
+    router.post('/_command/discover', buildDiscoverTask, sendTask);
 
     app.use('/', router);
 

--- a/lib/receivers/httpReceiver.js
+++ b/lib/receivers/httpReceiver.js
@@ -208,17 +208,12 @@ module.exports = (() => {
     next();
   }
 
-  function buildAuthTask(req, res, next) {
-    req.task = {
-      taskType: 'auth',
-      request: {
-        body: {
-          username: req.body.username,
-          password: req.body.password,
-          options: req.body.options
-        }
-      },
-      response: {}
+  function addAuthTaskAttributes(req, res, next) {
+    req.task.taskType = 'auth';
+    req.task.request.body = {
+      username: req.body.username,
+      password: req.body.password,
+      options: req.body.options
     };
 
     next();
@@ -256,7 +251,7 @@ module.exports = (() => {
 
     // FlexFunctions route
     router.post('/_flexFunctions/:handlerName', mapPostToElements, generateBaseTask, addFunctionsTaskAttributes, appendQuery, appendId, appendBody, sendTask);
-    router.post('/_auth/authenticate', buildAuthTask, sendTask);
+    router.post('/_auth/authenticate', generateBaseTask, addAuthTaskAttributes, sendTask);
 
     router.post('/_command/discover', buildDiscoverTask, sendTask);
 


### PR DESCRIPTION
Adds support in the http router for authentication endpoints to support `flex.auth` services.  