### PR TITLE
FLEX-171 Error handling

### DIFF
--- a/lib/receivers/tcpReceiver.js
+++ b/lib/receivers/tcpReceiver.js
@@ -12,16 +12,20 @@
 
 const net = require('net');
 const log = require('../log/logger');
+const { serialize } = require('../utils');
 
 function getSerializableError(err) {
   let errorToLog = err.toString();
 
   if (!(err instanceof Error)) {
+    log.debug('Error argument not an instance of Error');
     try {
-      JSON.stringify(err); // if err has circular references, this would fail
+      serialize(err); // if err has circular references, this would fail
       errorToLog = err;
     } catch (err) {
-      errorToLog = 'Error argument not instance of Error and not stringifiable';
+      const msg = 'Error argument not instance of Error and not stringifiable';
+      errorToLog = msg;
+      log.debug(msg);
     }
   }
 
@@ -91,7 +95,7 @@ module.exports = (() => {
             if (parseError) {
               log.error(`Parse error! ${parseError}`);
               parseError.isError = true;
-              socket.write(JSON.stringify(composeErrorReply('Internal Error', parseError.toString(), parseError)));
+              socket.write(serialize(composeErrorReply('Internal Error', parseError.toString(), parseError)));
               socket.write('\n');
               return;
             }
@@ -106,7 +110,7 @@ module.exports = (() => {
               if (err) {
                 log.debug('Responding with error');
                 log.error(err);
-                socket.write(JSON.stringify(composeErrorReply('Internal Error', 'Unable to execute Flex method', err)));
+                socket.write(serialize(composeErrorReply('Internal Error', 'Unable to execute Flex method', err)));
                 socket.write('\n');
                 return;
               }
@@ -120,7 +124,7 @@ module.exports = (() => {
               }
 
               // TODO: Check the size of ret and use a non-blocking serializer if too large
-              socket.write(JSON.stringify(result));
+              socket.write(serialize(result));
               socket.write('\n');
             });
           });
@@ -152,7 +156,7 @@ module.exports = (() => {
 
           if (task.indexOf('{"healthCheck":1}') > -1) {
             log.info('healthcheck!');
-            socket.write(`${JSON.stringify({ status: 'ready' })}\n`);
+            socket.write(`${serialize({ status: 'ready' })}\n`);
             return;
           }
 

--- a/lib/receivers/tcpReceiver.js
+++ b/lib/receivers/tcpReceiver.js
@@ -13,6 +13,23 @@
 const net = require('net');
 const log = require('../log/logger');
 
+function getSerializableError(err) {
+  let errorToLog;
+
+  if (err instanceof Error) {
+    errorToLog = err.toString();
+  } else {
+    try {
+      JSON.stringify(err); // if err has circular references, this would fail
+      errorToLog = err;
+    } catch (err) {
+      errorToLog = 'Error argument not instance of Error and not stringifiable';
+    }
+  }
+
+  return errorToLog;
+}
+
 module.exports = (() => {
   let server = {};
 
@@ -23,7 +40,7 @@ module.exports = (() => {
 
     return {
       isError: true,
-      error: err.toString(),
+      error: getSerializableError(err),
       message: errorMessage,
       debugMessage,
       // note: stack is not a stack array, it's a formatted text string that contains a printed stack trace
@@ -37,7 +54,7 @@ module.exports = (() => {
     log.debug(task);
 
     if (!task) {
-      return composeErrorReply('Internal Error', 'Bad Request', new Error('Bad Request'), {});
+      return callback(new Error('Invalid or missing task object'));
     }
 
     if (typeof task === 'object') {

--- a/lib/receivers/tcpReceiver.js
+++ b/lib/receivers/tcpReceiver.js
@@ -106,7 +106,7 @@ module.exports = (() => {
               if (err) {
                 log.debug('Responding with error');
                 log.error(err);
-                socket.write(JSON.stringify(composeErrorReply('Internal Error', 'Unable to run dlc script', err)));
+                socket.write(JSON.stringify(composeErrorReply('Internal Error', 'Unable to execute Flex method', err)));
                 socket.write('\n');
                 return;
               }

--- a/lib/receivers/tcpReceiver.js
+++ b/lib/receivers/tcpReceiver.js
@@ -14,11 +14,9 @@ const net = require('net');
 const log = require('../log/logger');
 
 function getSerializableError(err) {
-  let errorToLog;
+  let errorToLog = err.toString();
 
-  if (err instanceof Error) {
-    errorToLog = err.toString();
-  } else {
+  if (!(err instanceof Error)) {
     try {
       JSON.stringify(err); // if err has circular references, this would fail
       errorToLog = err;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,3 @@
+exports.serialize = (object) => {
+  return JSON.stringify(object);
+};

--- a/test/lib/tcpReceiver.test.js
+++ b/test/lib/tcpReceiver.test.js
@@ -182,7 +182,7 @@ describe('tcp receiver', () => {
             return done(err);
           }
           obj.isError.should.be.true();
-          obj.debugMessage.should.containEql('Unable to run dlc script');
+          obj.debugMessage.should.containEql('Unable to execute Flex method');
           obj.error.should.eql(new Error('some error message').toString());
           return done();
         });
@@ -200,7 +200,7 @@ describe('tcp receiver', () => {
             return done(err);
           }
           obj.isError.should.be.true();
-          obj.debugMessage.should.containEql('Unable to run dlc script');
+          obj.debugMessage.should.containEql('Unable to execute Flex method');
           obj.error.should.deepEqual({ test: true });
           return done();
         });
@@ -218,7 +218,7 @@ describe('tcp receiver', () => {
             return done(err);
           }
           obj.isError.should.be.true();
-          obj.debugMessage.should.containEql('Unable to run dlc script');
+          obj.debugMessage.should.containEql('Unable to execute Flex method');
           obj.error.should.eql('Error argument not instance of Error and not stringifiable');
           return done();
         });


### PR DESCRIPTION
Attempt to make error handling a bit more robust by handling cases when error object is not an instance of the Error class. Fix handling parse errors when no task object is passed, or it's an empty string. Add tests.