### PR TITLE
QA-216: Set node.js version used in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ env:
   global:
     - NODEJS_VERSION='6.11.1'
 
+before_install:
+  - npm i -g npm@^6.0.0
+
 matrix:
   include:
     - language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - NODEJS_VERSION='10.5.0'
+    - NODEJS_VERSION='6.11.1'
 
 matrix:
   include:


### PR DESCRIPTION
Changes:
 - set the node.js version that will be used in CI to 6.11.1